### PR TITLE
Add secrets file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Nuclear Power Plant Financial Model maker
 
 ## Power price utilities
 
-The `price_utils.py` module retrieves hourly power prices from the U.S. Energy Information Administration (EIA) API and provides a simple forecast utility. Set the environment variable `EIA_API_KEY` or pass the API key directly when calling `fetch_recent_prices`.
+The `price_utils.py` module retrieves hourly power prices from the U.S. Energy Information Administration (EIA) API and provides a simple forecast utility. Set the environment variable `EIA_API_KEY`, create a `secrets.json` file with the key, or pass the API key directly when calling `fetch_recent_prices`.
+
+Run `python create_secrets.py` to create the `secrets.json` file interactively. The module will read the key from this file if the environment variable is not set.
 
 Example:
 

--- a/create_secrets.py
+++ b/create_secrets.py
@@ -1,0 +1,17 @@
+import json
+from getpass import getpass
+from pathlib import Path
+
+
+def main():
+    key = getpass('Enter your EIA API key: ').strip()
+    secrets = {'EIA_API_KEY': key}
+    secrets_path = Path(__file__).resolve().parent / 'secrets.json'
+    with open(secrets_path, 'w', encoding='utf-8') as f:
+        json.dump(secrets, f)
+    print(f'Secrets written to {secrets_path}')
+
+
+if __name__ == '__main__':
+    main()
+

--- a/price_utils.py
+++ b/price_utils.py
@@ -1,4 +1,6 @@
 import os
+import json
+from pathlib import Path
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -26,8 +28,19 @@ def fetch_recent_prices(region: str, hours: int = 24, api_key: Optional[str] = N
     """
     if api_key is None:
         api_key = os.getenv("EIA_API_KEY")
+        if not api_key:
+            secrets_path = Path(__file__).resolve().parent / "secrets.json"
+            if secrets_path.exists():
+                try:
+                    with open(secrets_path, "r", encoding="utf-8") as f:
+                        secrets = json.load(f)
+                        api_key = secrets.get("EIA_API_KEY")
+                except Exception:
+                    pass
     if not api_key:
-        raise ValueError("An EIA API key is required. Set EIA_API_KEY env variable or pass api_key argument.")
+        raise ValueError(
+            "An EIA API key is required. Set EIA_API_KEY env variable, pass api_key argument, or create secrets.json."
+        )
 
     end = datetime.utcnow()
     start = end - timedelta(hours=hours)


### PR DESCRIPTION
## Summary
- allow `price_utils` to read an API key from `secrets.json`
- add helper script `create_secrets.py` to create the secrets file
- document the new secrets workflow in the README

## Testing
- `python -m py_compile plant.py`
- `python plant.py`
- `python -m py_compile price_utils.py`
- `python -m py_compile create_secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_687fe2615074832d9c0c4528c2690b93