### PR TITLE
Add multi-year daily price forecasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Nuclear Power Plant Financial Model maker
 
 ## Power price utilities
 
-The `price_utils.py` module retrieves hourly power prices from the U.S. Energy Information Administration (EIA) API and provides a simple forecast utility. Set the environment variable `EIA_API_KEY`, create a `secrets.json` file with the key, or pass the API key directly when calling `fetch_recent_prices`.
+The `price_utils.py` module retrieves hourly or daily power prices from the U.S. Energy Information Administration (EIA) API and provides simple forecast utilities. Set the environment variable `EIA_API_KEY`, create a `secrets.json` file with the key, or pass the API key directly when calling the fetch functions.
 
 Run `python create_secrets.py` to create the `secrets.json` file interactively. The module will read the key from this file if the environment variable is not set.
 
@@ -20,4 +20,15 @@ print("Forecasted price:", next_hour)
 # Forecast using an ARIMA model with automatic parameter tuning
 next_hour_arima = forecast_arima(prices)
 print("ARIMA forecast:", next_hour_arima)
+```
+
+You can also retrieve daily prices over multiple years and compute a seasonal forecast:
+
+```python
+from price_utils import fetch_daily_prices, forecast_next_day_seasonal
+
+# Pull three years of daily data and forecast tomorrow's price
+prices_daily = fetch_daily_prices(region="NY", years=3, api_key="YOUR_KEY")
+next_day = forecast_next_day_seasonal(prices_daily)
+print("Seasonal forecast:", next_day)
 ```


### PR DESCRIPTION
## Summary
- support fetching daily power prices
- provide seasonal forecasting using daily data
- document the new utilities

## Testing
- `python -m py_compile plant.py`
- `python plant.py`
- `python -m py_compile price_utils.py`
- `python price_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687fe5d705a0832d8f0c004ccbbdad82