### PR TITLE
Fix LCOE output and add tests

### DIFF
--- a/plant.py
+++ b/plant.py
@@ -155,7 +155,9 @@ if __name__ == '__main__':
     print(f"  - Annual Energy Output: {ANNUAL_ENERGY_PRODUCTION_MWH:,.0f} MWh")
 
     print("\n--- Model Results ---")
-    print(f"Levelized Cost of Energy (LCOE): ${lcoe_result:,.2f} per MWh")
+    # Convert from millions of dollars to dollars per MWh for readability
+    lcoe_dollars = lcoe_result * 1_000_000
+    print(f"Levelized Cost of Energy (LCOE): ${lcoe_dollars:,.2f} per MWh")
     print("\nThis LCOE represents the minimum average price at which electricity must be sold")
     print("for the project to break even over its lifetime (i.e., achieve an NPV of zero).")
 

--- a/tests/test_arima.py
+++ b/tests/test_arima.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from price_utils import forecast_arima
+
+
+def test_forecast_arima_constant():
+    # Constant price should forecast same value
+    data = pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=30, freq="H"),
+        "price": [5.0]*30
+    })
+    forecast = forecast_arima(data, order=(1,0,0))
+    assert abs(forecast - 5.0) < 1e-1

--- a/tests/test_financial.py
+++ b/tests/test_financial.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from plant import calculate_npv, calculate_lcoe, calculate_discounted_payback_period
+from price_utils import forecast_next_hour, forecast_next_day_seasonal
+
+
+def test_calculate_npv():
+    cash_flows = [-100, 60, 60]
+    npv = calculate_npv(cash_flows, 0.1)
+    # NPV = -100/(1+0.1)^1 + 60/(1+0.1)^2 + 60/(1+0.1)^3
+    expected = cash_flows[0] / 1.1 + cash_flows[1] / 1.1**2 + cash_flows[2] / 1.1**3
+    assert abs(npv - expected) < 1e-8
+
+
+def test_calculate_lcoe():
+    invest = [50, 0]
+    op = [0, 10]
+    energy = [0, 100]
+    lcoe = calculate_lcoe(invest, op, energy, 0.1)
+    # discounted costs: 50/(1.1) + 10/(1.1**2)
+    costs = 50/1.1 + 10/(1.1**2)
+    energy_discounted = 100/(1.1**2)
+    expected = costs / energy_discounted
+    assert abs(lcoe - expected) < 1e-8
+
+
+def test_discounted_payback_period():
+    cash_flows = [-100, 40, 40, 40]
+    dpp = calculate_discounted_payback_period(cash_flows, 0.05)
+    assert dpp == 3
+
+
+def test_forecast_next_hour():
+    timestamps = pd.date_range("2024-01-01", periods=24, freq="H")
+    prices = pd.DataFrame({"timestamp": timestamps, "price": range(24)})
+    assert forecast_next_hour(prices) == sum(range(0,24))/24
+
+
+def test_forecast_next_day_seasonal():
+    timestamps = pd.date_range("2023-01-01", periods=365, freq="D")
+    prices = pd.DataFrame({"timestamp": timestamps, "price": 2.0})
+    # All prices the same -> forecast should equal that price
+    assert forecast_next_day_seasonal(prices) == 2.0


### PR DESCRIPTION
## Summary
- fix `plant.py` output by converting LCOE to dollars per MWh
- add unit tests covering financial calculations and price utilities

## Testing
- `python -m py_compile plant.py`
- `python plant.py | head -n 10`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe6dee958832d8fb522b0ffcd45a6