### PR TITLE
Add plant operation simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,23 @@ prices_daily = fetch_daily_prices(region="NY", years=3, api_key="YOUR_KEY")
 next_day = forecast_next_day_seasonal(prices_daily)
 print("Seasonal forecast:", next_day)
 ```
+
+## Plant operation simulation
+
+`plant.py` includes a `simulate_plant_operation` function for modeling plant
+profitability against hourly price data. The function accounts for scheduled
+maintenance downtime, fuel costs, and the plant's capacity factor.
+
+Example:
+
+```python
+import pandas as pd
+from plant import simulate_plant_operation
+
+timestamps = pd.date_range("2024-01-01", periods=48, freq="H")
+prices = pd.DataFrame({"timestamp": timestamps, "price": 50.0})
+profit, results = simulate_plant_operation(prices, capacity_mw=1000,
+                                           fuel_cost_per_mwh=10,
+                                           maintenance_days=1)
+print("Profit:", profit)
+```

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from plant import simulate_plant_operation
+
+
+def test_simulate_plant_operation():
+    timestamps = pd.date_range("2024-01-01", periods=48, freq="H")
+    prices = pd.DataFrame({"timestamp": timestamps, "price": 50.0})
+    profit, _ = simulate_plant_operation(prices, capacity_mw=1000,
+                                         fuel_cost_per_mwh=10,
+                                         maintenance_days=1,
+                                         capacity_factor=1.0)
+    # 24 hours offline -> 24 hours running at 1000 MW
+    energy = 24 * 1000
+    expected = (50.0 * energy) - (10 * energy)
+    assert abs(profit - expected) < 1e-6


### PR DESCRIPTION
## Summary
- implement `simulate_plant_operation` for downtime and fuel-cost-aware profit calculation
- demonstrate the simulation in `plant.py`
- document the new feature in the README
- add unit test for the simulator

## Testing
- `python -m py_compile plant.py`
- `python plant.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe8513834832dabe7849e44225f20