### PR TITLE
Add fuel refueling cost support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ print("Seasonal forecast:", next_day)
 
 `plant.py` includes a `simulate_plant_operation` function for modeling plant
 profitability against hourly price data. The function accounts for scheduled
-maintenance downtime, fuel costs, and the plant's capacity factor.
+maintenance downtime, fuel costs, and the plant's capacity factor. Fuel costs
+can be specified either directly in dollars per MWh or as a total cost per
+refueling cycle, which is then converted to a per-MWh value.
 
 Example:
 
@@ -51,6 +53,16 @@ profit, results = simulate_plant_operation(prices, capacity_mw=1000,
                                            fuel_cost_per_mwh=10,
                                            maintenance_days=1)
 print("Profit:", profit)
+```
+
+Fuel cost can also be provided per refueling cycle:
+
+```python
+refuel_cost = 10 * 1000 * 24 * 18 * 30  # equivalent to $10/MWh for a cycle
+profit, _ = simulate_plant_operation(prices, capacity_mw=1000,
+                                     fuel_cost_per_mwh=None,
+                                     fuel_cost_per_refueling=refuel_cost,
+                                     maintenance_days=1)
 ```
 
 An example set of plant parameters is provided in `example_plant.json`. Running

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -19,3 +19,21 @@ def test_simulate_plant_operation():
     energy = 24 * 1000
     expected = (50.0 * energy) - (10 * energy)
     assert abs(profit - expected) < 1e-6
+
+def test_simulate_refueling_cost():
+    timestamps = pd.date_range("2024-01-01", periods=48, freq="H")
+    prices = pd.DataFrame({"timestamp": timestamps, "price": 50.0})
+    hours_per_cycle = 18 * 30 * 24
+    energy_cycle = 1000 * 1.0 * hours_per_cycle
+    refuel_cost = 10 * energy_cycle
+    profit_mwh, _ = simulate_plant_operation(
+        prices,
+        capacity_mw=1000,
+        fuel_cost_per_mwh=None,
+        maintenance_days=1,
+        capacity_factor=1.0,
+        fuel_cost_per_refueling=refuel_cost,
+    )
+    energy = 24 * 1000
+    expected = (50.0 * energy) - (10 * energy)
+    assert abs(profit_mwh - expected) < 1e-6


### PR DESCRIPTION
## Summary
- allow `simulate_plant_operation` to take a total refueling cost
- convert refueling cost to $/MWh when needed
- document how to use refueling cost option
- test refueling cost handling

## Testing
- `python -m py_compile plant.py`
- `python plant.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fee3916b0832d81826595f0ead8ea