### PR TITLE
Add plant templates and CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,12 @@ profit, _ = simulate_plant_operation(prices, capacity_mw=1000,
 
 An example set of plant parameters is provided in `example_plant.json`. Running
 `python plant.py` will load this file and execute a full financial calculation
-using those values.
+using those values. Additional templates are available in the `plant_templates`
+directory. Specify one with the `--params` flag:
+
+```bash
+python plant.py --params plant_templates/vogtle.json
+```
+
+Current templates include `vogtle.json`, `generic_pwr_1970s.json`, and
+`generic_smr.json` for comparing different plant designs.

--- a/plant.py
+++ b/plant.py
@@ -289,8 +289,20 @@ def run_example(params: dict) -> None:
 
 # --- Main execution block with an example scenario ---
 def main() -> None:
-    params_path = Path(__file__).resolve().parent / "example_plant.json"
-    params = load_parameters(params_path)
+    """Run the financial model using parameters from a JSON file."""
+    import argparse
+
+    default_path = Path(__file__).resolve().parent / "example_plant.json"
+    parser = argparse.ArgumentParser(description="Run the nuclear plant model")
+    parser.add_argument(
+        "--params",
+        type=Path,
+        default=default_path,
+        help="Path to plant parameter JSON file",
+    )
+    args = parser.parse_args()
+
+    params = load_parameters(args.params)
     print("--- Financial Model for a Hypothetical Nuclear Power Plant ---")
     run_example(params)
 

--- a/plant_templates/generic_pwr_1970s.json
+++ b/plant_templates/generic_pwr_1970s.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 7,
+  "operational_life_years": 50,
+  "discount_rate": 0.08,
+  "overnight_cost_usd_million": 5000,
+  "annual_operation_cost_usd_million": 120,
+  "op_cost_inflation": 0.02,
+  "decommissioning_cost_usd_million": 800,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 1000,
+  "capacity_factor": 0.88,
+  "electricity_price_usd_per_mwh": 80,
+  "fuel_cost_per_mwh": 9.0,
+  "maintenance_days": 40
+}

--- a/plant_templates/generic_smr.json
+++ b/plant_templates/generic_smr.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 5,
+  "operational_life_years": 40,
+  "discount_rate": 0.08,
+  "overnight_cost_usd_million": 4000,
+  "annual_operation_cost_usd_million": 60,
+  "op_cost_inflation": 0.02,
+  "decommissioning_cost_usd_million": 500,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 300,
+  "capacity_factor": 0.95,
+  "electricity_price_usd_per_mwh": 100,
+  "fuel_cost_per_mwh": 6.0,
+  "maintenance_days": 25
+}

--- a/plant_templates/vogtle.json
+++ b/plant_templates/vogtle.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 10,
+  "operational_life_years": 60,
+  "discount_rate": 0.08,
+  "overnight_cost_usd_million": 28000,
+  "annual_operation_cost_usd_million": 400,
+  "op_cost_inflation": 0.02,
+  "decommissioning_cost_usd_million": 1200,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 2200,
+  "capacity_factor": 0.92,
+  "electricity_price_usd_per_mwh": 70,
+  "fuel_cost_per_mwh": 7.0,
+  "maintenance_days": 35
+}


### PR DESCRIPTION
## Summary
- allow selecting plant parameter file with `--params` flag
- document and show how to run with new templates
- provide several plant templates (Vogtle, generic PWR, generic SMR)

## Testing
- `python -m py_compile plant.py`
- `python plant.py --params plant_templates/vogtle.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ff00727e0832d886e93855c15ebad