### PR TITLE
Add plant templates and CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,23 @@ profit, _ = simulate_plant_operation(prices, capacity_mw=1000,
 
 An example set of plant parameters is provided in `example_plant.json`. Running
 `python plant.py` will load this file and execute a full financial calculation
-using those values.
+using those values. Additional templates are available in the `plant_templates`
+directory. Specify one with the `--params` flag:
+
+```bash
+python plant.py --params plant_templates/vogtle.json
+```
+
+A variety of parameter sets are available for comparing different plant
+designs. Some examples include:
+
+```
+akkuyu.json              hinkley_point_c.json  nuscale_smr.json
+ap1000_nth.json          generic_amr_htgr.json plex_pwr.json
+barakah.json             generic_pwr_1970s.json shin_kori_apr1400.json
+darlington_refurb.json   generic_smr.json       vogtle.json
+flamanville3.json
+```
+
+Use any of these with the `--params` flag to explore how different projects
+affect the model outputs.

--- a/plant.py
+++ b/plant.py
@@ -289,8 +289,20 @@ def run_example(params: dict) -> None:
 
 # --- Main execution block with an example scenario ---
 def main() -> None:
-    params_path = Path(__file__).resolve().parent / "example_plant.json"
-    params = load_parameters(params_path)
+    """Run the financial model using parameters from a JSON file."""
+    import argparse
+
+    default_path = Path(__file__).resolve().parent / "example_plant.json"
+    parser = argparse.ArgumentParser(description="Run the nuclear plant model")
+    parser.add_argument(
+        "--params",
+        type=Path,
+        default=default_path,
+        help="Path to plant parameter JSON file",
+    )
+    args = parser.parse_args()
+
+    params = load_parameters(args.params)
     print("--- Financial Model for a Hypothetical Nuclear Power Plant ---")
     run_example(params)
 

--- a/plant_templates/akkuyu.json
+++ b/plant_templates/akkuyu.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 8,
+  "operational_life_years": 60,
+  "discount_rate": 0.08,
+  "overnight_cost_usd_million": 22000,
+  "annual_operation_cost_usd_million": 800,
+  "op_cost_inflation": 0.03,
+  "decommissioning_cost_usd_million": 1800,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 4800,
+  "capacity_factor": 0.90,
+  "electricity_price_usd_per_mwh": 68,
+  "fuel_cost_per_mwh": 6.0,
+  "maintenance_days": 30
+}

--- a/plant_templates/ap1000_nth.json
+++ b/plant_templates/ap1000_nth.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 7,
+  "operational_life_years": 80,
+  "discount_rate": 0.08,
+  "overnight_cost_usd_million": 18000,
+  "annual_operation_cost_usd_million": 350,
+  "op_cost_inflation": 0.02,
+  "decommissioning_cost_usd_million": 1500,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 2200,
+  "capacity_factor": 0.93,
+  "electricity_price_usd_per_mwh": 72,
+  "fuel_cost_per_mwh": 7.0,
+  "maintenance_days": 25
+}

--- a/plant_templates/barakah.json
+++ b/plant_templates/barakah.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 9,
+  "operational_life_years": 60,
+  "discount_rate": 0.075,
+  "overnight_cost_usd_million": 24000,
+  "annual_operation_cost_usd_million": 900,
+  "op_cost_inflation": 0.015,
+  "decommissioning_cost_usd_million": 2000,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 5600,
+  "capacity_factor": 0.90,
+  "electricity_price_usd_per_mwh": 65,
+  "fuel_cost_per_mwh": 6.5,
+  "maintenance_days": 28
+}

--- a/plant_templates/darlington_refurb.json
+++ b/plant_templates/darlington_refurb.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 10,
+  "operational_life_years": 30,
+  "discount_rate": 0.065,
+  "overnight_cost_usd_million": 9500,
+  "annual_operation_cost_usd_million": 650,
+  "op_cost_inflation": 0.02,
+  "decommissioning_cost_usd_million": 2500,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 3512,
+  "capacity_factor": 0.88,
+  "electricity_price_usd_per_mwh": 60,
+  "fuel_cost_per_mwh": 5.0,
+  "maintenance_days": 45
+}

--- a/plant_templates/flamanville3.json
+++ b/plant_templates/flamanville3.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 17,
+  "operational_life_years": 60,
+  "discount_rate": 0.07,
+  "overnight_cost_usd_million": 21000,
+  "annual_operation_cost_usd_million": 380,
+  "op_cost_inflation": 0.025,
+  "decommissioning_cost_usd_million": 1500,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 1650,
+  "capacity_factor": 0.88,
+  "electricity_price_usd_per_mwh": 110,
+  "fuel_cost_per_mwh": 8.0,
+  "maintenance_days": 35
+}

--- a/plant_templates/generic_amr_htgr.json
+++ b/plant_templates/generic_amr_htgr.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 3,
+  "operational_life_years": 60,
+  "discount_rate": 0.09,
+  "overnight_cost_usd_million": 2000,
+  "annual_operation_cost_usd_million": 70,
+  "op_cost_inflation": 0.02,
+  "decommissioning_cost_usd_million": 250,
+  "residual_value_usd_million": 50,
+  "plant_capacity_mw": 300,
+  "capacity_factor": 0.94,
+  "electricity_price_usd_per_mwh": 75,
+  "fuel_cost_per_mwh": 12.0,
+  "maintenance_days": 15
+}

--- a/plant_templates/generic_pwr_1970s.json
+++ b/plant_templates/generic_pwr_1970s.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 7,
+  "operational_life_years": 50,
+  "discount_rate": 0.08,
+  "overnight_cost_usd_million": 5000,
+  "annual_operation_cost_usd_million": 120,
+  "op_cost_inflation": 0.02,
+  "decommissioning_cost_usd_million": 800,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 1000,
+  "capacity_factor": 0.88,
+  "electricity_price_usd_per_mwh": 80,
+  "fuel_cost_per_mwh": 9.0,
+  "maintenance_days": 40
+}

--- a/plant_templates/generic_smr.json
+++ b/plant_templates/generic_smr.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 5,
+  "operational_life_years": 40,
+  "discount_rate": 0.08,
+  "overnight_cost_usd_million": 4000,
+  "annual_operation_cost_usd_million": 60,
+  "op_cost_inflation": 0.02,
+  "decommissioning_cost_usd_million": 500,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 300,
+  "capacity_factor": 0.95,
+  "electricity_price_usd_per_mwh": 100,
+  "fuel_cost_per_mwh": 6.0,
+  "maintenance_days": 25
+}

--- a/plant_templates/hinkley_point_c.json
+++ b/plant_templates/hinkley_point_c.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 14,
+  "operational_life_years": 60,
+  "discount_rate": 0.07,
+  "overnight_cost_usd_million": 40000,
+  "annual_operation_cost_usd_million": 750,
+  "op_cost_inflation": 0.025,
+  "decommissioning_cost_usd_million": 3500,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 3260,
+  "capacity_factor": 0.90,
+  "electricity_price_usd_per_mwh": 120,
+  "fuel_cost_per_mwh": 8.0,
+  "maintenance_days": 30
+}

--- a/plant_templates/nuscale_smr.json
+++ b/plant_templates/nuscale_smr.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 4,
+  "operational_life_years": 60,
+  "discount_rate": 0.08,
+  "overnight_cost_usd_million": 3500,
+  "annual_operation_cost_usd_million": 100,
+  "op_cost_inflation": 0.02,
+  "decommissioning_cost_usd_million": 300,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 462,
+  "capacity_factor": 0.95,
+  "electricity_price_usd_per_mwh": 85,
+  "fuel_cost_per_mwh": 9.0,
+  "maintenance_days": 20
+}

--- a/plant_templates/plex_pwr.json
+++ b/plant_templates/plex_pwr.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 3,
+  "operational_life_years": 20,
+  "discount_rate": 0.08,
+  "overnight_cost_usd_million": 1800,
+  "annual_operation_cost_usd_million": 200,
+  "op_cost_inflation": 0.02,
+  "decommissioning_cost_usd_million": 1000,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 1150,
+  "capacity_factor": 0.92,
+  "electricity_price_usd_per_mwh": 50,
+  "fuel_cost_per_mwh": 7.5,
+  "maintenance_days": 30
+}

--- a/plant_templates/shin_kori_apr1400.json
+++ b/plant_templates/shin_kori_apr1400.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 6,
+  "operational_life_years": 60,
+  "discount_rate": 0.05,
+  "overnight_cost_usd_million": 7000,
+  "annual_operation_cost_usd_million": 450,
+  "op_cost_inflation": 0.015,
+  "decommissioning_cost_usd_million": 800,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 2800,
+  "capacity_factor": 0.92,
+  "electricity_price_usd_per_mwh": 55,
+  "fuel_cost_per_mwh": 6.5,
+  "maintenance_days": 28
+}

--- a/plant_templates/vogtle.json
+++ b/plant_templates/vogtle.json
@@ -1,0 +1,15 @@
+{
+  "construction_period_years": 10,
+  "operational_life_years": 60,
+  "discount_rate": 0.08,
+  "overnight_cost_usd_million": 28000,
+  "annual_operation_cost_usd_million": 400,
+  "op_cost_inflation": 0.02,
+  "decommissioning_cost_usd_million": 1200,
+  "residual_value_usd_million": 0,
+  "plant_capacity_mw": 2200,
+  "capacity_factor": 0.92,
+  "electricity_price_usd_per_mwh": 70,
+  "fuel_cost_per_mwh": 7.0,
+  "maintenance_days": 35
+}


### PR DESCRIPTION
## Summary
- allow selecting plant parameter file with `--params` flag
- document and show how to run with new templates
- provide several plant templates (Vogtle, generic PWR, generic SMR)
- add more detailed templates for projects like Hinkley Point C, Barakah, and others

## Testing
- `python -m py_compile plant.py`
- `python plant.py --params plant_templates/vogtle.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ff00727e0832d886e93855c15ebad